### PR TITLE
Setting default access key length to 20

### DIFF
--- a/android/conf/local.conf.js
+++ b/android/conf/local.conf.js
@@ -2,7 +2,7 @@ var browserstack = require('browserstack-local');
 
 exports.config = {
   user: process.env.BROWSERSTACK_USERNAME || 'BROWSERSTACK_USERNAME',
-  key: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACCESS_KEY',
+  key: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACC_KEY',
 
   updateJob: false,
   specs: [

--- a/android/conf/multiple.conf.js
+++ b/android/conf/multiple.conf.js
@@ -1,6 +1,6 @@
 exports.config = {
   user: process.env.BROWSERSTACK_USERNAME || 'BROWSERSTACK_USERNAME',
-  key: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACCESS_KEY',
+  key: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACC_KEY',
 
   updateJob: false,
   specs: [

--- a/android/conf/parallel.conf.js
+++ b/android/conf/parallel.conf.js
@@ -1,6 +1,6 @@
 exports.config = {
   user: process.env.BROWSERSTACK_USERNAME || 'BROWSERSTACK_USERNAME',
-  key: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACCESS_KEY',
+  key: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACC_KEY',
 
   updateJob: false,
   specs: [

--- a/android/conf/single.conf.js
+++ b/android/conf/single.conf.js
@@ -1,6 +1,6 @@
 exports.config = {
   user: process.env.BROWSERSTACK_USERNAME || 'BROWSERSTACK_USERNAME',
-  key: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACCESS_KEY',
+  key: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACC_KEY',
 
   updateJob: false,
   specs: [

--- a/ios/conf/local.conf.js
+++ b/ios/conf/local.conf.js
@@ -2,7 +2,7 @@ var browserstack = require('browserstack-local');
 
 exports.config = {
   user: process.env.BROWSERSTACK_USERNAME || 'BROWSERSTACK_USERNAME',
-  key: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACCESS_KEY',
+  key: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACC_KEY',
 
   updateJob: false,
   specs: [

--- a/ios/conf/multiple.conf.js
+++ b/ios/conf/multiple.conf.js
@@ -1,6 +1,6 @@
 exports.config = {
   user: process.env.BROWSERSTACK_USERNAME || 'BROWSERSTACK_USERNAME',
-  key: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACCESS_KEY',
+  key: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACC_KEY',
 
   updateJob: false,
   specs: [

--- a/ios/conf/parallel.conf.js
+++ b/ios/conf/parallel.conf.js
@@ -1,6 +1,6 @@
 exports.config = {
   user: process.env.BROWSERSTACK_USERNAME || 'BROWSERSTACK_USERNAME',
-  key: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACCESS_KEY',
+  key: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACC_KEY',
 
   updateJob: false,
   specs: [

--- a/ios/conf/single.conf.js
+++ b/ios/conf/single.conf.js
@@ -1,6 +1,6 @@
 exports.config = {
   user: process.env.BROWSERSTACK_USERNAME || 'BROWSERSTACK_USERNAME',
-  key: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACCESS_KEY',
+  key: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACC_KEY',
 
   updateJob: false,
   specs: [


### PR DESCRIPTION
- WebDriver IO determines the cloud provider by the length of access key
- In case the env variable BROWSERSTACK_ACCESS_KEY is empty, we set it to
string BROWSERSTACK_ACC_KEY which is 20 characters

Goal: To avoid confusing error message in case the env variable is empty