### PR TITLE
setting the acccessiblity flag as false

### DIFF
--- a/android/examples/run-parallel-test/parallel.conf.js
+++ b/android/examples/run-parallel-test/parallel.conf.js
@@ -8,7 +8,7 @@ exports.config = {
     [
       'browserstack',
       {
-        accessibility: true,
+        accessibility: false,
         buildIdentifier: '${BUILD_NUMBER}',
         browserstackLocal: true,
         opts: { forcelocal: false, localIdentifier: "webdriverio-appium-app-browserstack-repo" },


### PR DESCRIPTION
Final changes:
1. For WDIO framework support on App A11y Automate, we would need to update the sample Wikipedia app in the sample repo to support WDIO integration for App A11y.

2. Also, in the browserstack yml file in the sample repo, we need to add the accessibility label as false by default so the user just has to make it true for enabling app a11y checks.